### PR TITLE
feat: Default to `bigint = "integer"`

### DIFF
--- a/R/AdbiConnection.R
+++ b/R/AdbiConnection.R
@@ -80,19 +80,13 @@ DBI::dbWithTransaction
 
 resolve_bigint <- function(x) {
 
-  has_bit64 <- requireNamespace("bit64", quietly = TRUE)
-
   if (is.null(x)) {
-    if (has_bit64) {
-      x <- "integer64"
-    } else {
-      x <- "character"
-    }
+    x <- "integer"
   }
 
   res <- match.arg(x, c("integer", "numeric", "character", "integer64"))
 
-  if (res == "integer64" && !has_bit64) {
+  if (res == "integer64" && !requireNamespace("bit64", quietly = TRUE)) {
     stop("Need to install bit64.", call. = FALSE)
   }
 

--- a/tests/testthat/helper-DBItest.R
+++ b/tests/testthat/helper-DBItest.R
@@ -14,7 +14,7 @@ DBItest::make_context(
       date_cast = function(x) paste0("'", x, "'"),
       time_cast = function(x) paste0("'", x, "'"),
       timestamp_cast = function(x) paste0("'", x, "'"),
-      logical_return = function(x) bit64::as.integer64(x),
+      logical_return = function(x) as.integer(x),
       date_typed = FALSE,
       time_typed = FALSE,
       timestamp_typed = FALSE,


### PR DESCRIPTION
Defaulting to `integer64` does more harm than good in my opinion. Happy to discuss.