### PR TITLE
test: Bump version of supported DBItest spec

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -28,6 +28,9 @@ Suggests:
     withr,
     bit64,
     utils
+Remotes: 
+    r-dbi/DBI,
+    r-dbi/DBItest
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.2.3

--- a/man/AdbiConnection-class.Rd
+++ b/man/AdbiConnection-class.Rd
@@ -138,7 +138,8 @@ e.g. \code{Id(schema = "my_schema", table = "table_name")}
 given verbatim, e.g. \code{SQL('"my_schema"."table_name"')}
 }}
 
-\item{value}{a \link{data.frame} (or coercible to data.frame).}
+\item{value}{For \code{dbWriteTable()}, a \link{data.frame} (or coercible to data.frame).
+For \code{dbWriteTableArrow()}, an object coercible to an Arrow RecordBatchReader.}
 
 \item{...}{Other parameters passed on to methods.}
 

--- a/tests/testthat/helper-DBItest.R
+++ b/tests/testthat/helper-DBItest.R
@@ -8,7 +8,7 @@ DBItest::make_context(
   ),
   tweaks = suppressWarnings(
     DBItest::tweaks(
-      dbitest_version = "1.7.3",
+      dbitest_version = "1.8.0",
       constructor_relax_args = TRUE,
       placeholder_pattern = c("?", "$1", "$name", ":name"),
       date_cast = function(x) paste0("'", x, "'"),


### PR DESCRIPTION
Should work on top of #13.

~~This works better after #9, but one test failure gives me pause: `arrow_read_table_arrow` fails for no apparent reason, returning numerics where the input is an integer column.~~