### PR TITLE
fix: Avoid S4 warning due to method dispatch ambiguity for `dbQuoteString()` and `dbQuoteIdentifier()`

### DIFF
--- a/R/dbQuoteIdentifier_AdbiConnection_character.R
+++ b/R/dbQuoteIdentifier_AdbiConnection_character.R
@@ -12,3 +12,11 @@ setMethod(
   c("AdbiConnection", "character"),
   dbQuoteIdentifier_AdbiConnection_character
 )
+
+#' @rdname AdbiConnection-class
+#' @export
+setMethod(
+  "dbQuoteIdentifier",
+  c("AdbiConnection", "SQL"),
+  dbQuoteIdentifier_AdbiConnection_character
+)

--- a/R/dbQuoteString_AdbiConnection_character.R
+++ b/R/dbQuoteString_AdbiConnection_character.R
@@ -12,3 +12,11 @@ setMethod(
   c("AdbiConnection", "character"),
   dbQuoteString_AdbiConnection_character
 )
+
+#' @rdname AdbiConnection-class
+#' @export
+setMethod(
+  "dbQuoteString",
+  c("AdbiConnection", "SQL"),
+  dbQuoteString_AdbiConnection_character
+)

--- a/man/AdbiConnection-class.Rd
+++ b/man/AdbiConnection-class.Rd
@@ -49,10 +49,12 @@
 \alias{dbListTables,AdbiConnection-method}
 \alias{dbQuoteIdentifier_AdbiConnection_character}
 \alias{dbQuoteIdentifier,AdbiConnection,character-method}
+\alias{dbQuoteIdentifier,AdbiConnection,SQL-method}
 \alias{dbQuoteLiteral_AdbiConnection_character}
 \alias{dbQuoteLiteral,AdbiConnection,character-method}
 \alias{dbQuoteString_AdbiConnection_character}
 \alias{dbQuoteString,AdbiConnection,character-method}
+\alias{dbQuoteString,AdbiConnection,SQL-method}
 \alias{dbRemoveTable_AdbiConnection}
 \alias{dbRemoveTable,AdbiConnection,character-method}
 \alias{dbRemoveTable,AdbiConnection,Id-method}
@@ -98,9 +100,13 @@
 
 \S4method{dbQuoteIdentifier}{AdbiConnection,character}(conn, x, ...)
 
+\S4method{dbQuoteIdentifier}{AdbiConnection,SQL}(conn, x, ...)
+
 \S4method{dbQuoteLiteral}{AdbiConnection,character}(conn, x, ...)
 
 \S4method{dbQuoteString}{AdbiConnection,character}(conn, x, ...)
+
+\S4method{dbQuoteString}{AdbiConnection,SQL}(conn, x, ...)
 
 \S4method{dbRemoveTable}{AdbiConnection,character}(conn, name, ..., temporary = FALSE, fail_if_missing = TRUE)
 


### PR DESCRIPTION
git rev-parse --abbrev-ref HEAD | tr '-' '\n' | ghead -n -1 | gsed -r -n '/^([0-9]+)$/ {s//Closes #\1./;p}'