### PR TITLE
Update README

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -25,7 +25,13 @@ Bringing [arrow-adbc](https://github.com/apache/arrow-adbc) to R via [DBI](https
 
 ## Installation
 
-You can install the development version of adbi from [GitHub](https://github.com/) with:
+Install the latest release of adbi from CRAN with the following code:
+
+```r
+install.packages("adbi")
+```
+
+To get a bug fix or to use a feature from the development version, you can install the development version of adbi from GitHub:
 
 ``` r
 # install.packages("devtools")
@@ -37,6 +43,10 @@ devtools::install_github("r-dbi/adbi")
 The `data.frame` API of DBI is supported.
 
 ```{r df}
+# To run this example, please install the adbcsqlite package first.
+# 
+# install.packages("adbcsqlite")
+
 library(DBI)
 
 # Create an SQLite connection using the adbcsqlite backend

--- a/README.md
+++ b/README.md
@@ -18,8 +18,14 @@ database access.
 
 ## Installation
 
-You can install the development version of adbi from
-[GitHub](https://github.com/) with:
+Install the latest release of adbi from CRAN with the following code:
+
+``` r
+install.packages("adbi")
+```
+
+To get a bug fix or to use a feature from the development version, you
+can install the development version of adbi from GitHub:
 
 ``` r
 # install.packages("devtools")
@@ -31,6 +37,10 @@ devtools::install_github("r-dbi/adbi")
 The `data.frame` API of DBI is supported.
 
 ``` r
+# To run this example, please install the adbcsqlite package first.
+# 
+# install.packages("adbcsqlite")
+
 library(DBI)
 
 # Create an SQLite connection using the adbcsqlite backend


### PR DESCRIPTION
Minor fixes:

* Use `install.packages()` in the Installation section.
* Add a note to suggest users to install the adbcsqlite package.