### PR TITLE
Align handling of dbGetQuery without parameters to odbc::odbc()

### DIFF
--- a/R/dbSendQueryArrow_AdbiConnection.R
+++ b/R/dbSendQueryArrow_AdbiConnection.R
@@ -2,11 +2,7 @@
 #' @inheritParams DBI::dbSendQueryArrow
 #' @usage NULL
 dbSendQueryArrow_AdbiConnection <- function(conn, statement, ...,
-    params = NULL, immediate = NULL, bigint = NULL) {
-
-  if (!is.null(params)) {
-    immediate <- FALSE
-  }
+    params = NULL, immediate = is.null(params), bigint = NULL) {
 
   res <- AdbiResultArrow(
     connection = conn,

--- a/R/dbSendQuery_AdbiConnection_character.R
+++ b/R/dbSendQuery_AdbiConnection_character.R
@@ -40,11 +40,7 @@
 #' @return An S4 class `AdbiResult` (inheriting from [DBIResult-class]).
 #' @usage NULL
 dbSendQuery_AdbiConnection_character <- function(conn, statement, ...,
-    params = NULL, immediate = NULL, bigint = NULL) {
-
-  if (!is.null(params)) {
-    immediate <- FALSE
-  }
+    params = NULL, immediate = is.null(params), bigint = NULL) {
 
   res <- AdbiResult(
     connection = conn,

--- a/R/dbSendStatement_AdbiConnection_character.R
+++ b/R/dbSendStatement_AdbiConnection_character.R
@@ -2,11 +2,7 @@
 #' @inheritParams DBI::dbSendStatement
 #' @usage NULL
 dbSendStatement_AdbiConnection_character <- function(conn, statement, ...,
-    params = NULL, immediate = NULL, bigint = NULL) {
-
-  if (!is.null(params)) {
-    immediate <- FALSE
-  }
+    params = NULL, immediate = is.null(params), bigint = NULL) {
 
   res <- AdbiResult(
     connection = conn,


### PR DESCRIPTION
Using `adbi` with the `adbcsnowflake` snowflake driver currently fails to execute any queries unless the `immediate = TRUE` argument is set. 

The `odbc` package automatically sets the `immediate` argument if the [`params` argument is null](https://github.com/r-dbi/odbc/blob/bf7cd404b5417b925dbec1026ac559d1ee09d88d/R/dbi-connection.R#L237), which also solves the error here