### PR TITLE
feat: support driver manager initialization

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -18,7 +18,7 @@ Depends:
 Imports: 
     DBI (>= 1.2.0),
     methods,
-    adbcdrivermanager (>= 0.8.0),
+    adbcdrivermanager (>= 0.23.0.9000),
     nanoarrow (>= 0.3.0)
 Suggests: 
     testthat,
@@ -29,7 +29,8 @@ Suggests:
     bit64,
     utils,
     arrow
-Remotes: 
+Remotes:
+    apache/arrow-adbc/r/adbcdrivermanager,
     r-dbi/DBItest
 Config/Needs/website: 
     r-dbi/dbitemplate

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -30,7 +30,7 @@ Suggests:
     utils,
     arrow
 Remotes:
-    apache/arrow-adbc/r/adbcdrivermanager,
+    adbcdrivermanager=github::apache/arrow-adbc/r/adbcdrivermanager,
     r-dbi/DBItest
 Config/Needs/website: 
     r-dbi/dbitemplate

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,12 @@
+# adbi (development version)
+
+- `adbi()` now defaults to driver-manager inference. It accepts connection
+  profile URIs, ordinary URIs, driver or manifest names and paths, as well as
+  existing `adbc_driver` objects.
+- Resolving an R driver from a function, `pkg::fun`, or installed package name
+  is deprecated. Pass the driver object directly instead.
+- A database allocated during a failed connection attempt is now released.
+
 # adbi 0.1.2 (2024-09-03)
 
 - Docs only update

--- a/R/AdbiConnection.R
+++ b/R/AdbiConnection.R
@@ -8,19 +8,30 @@ AdbiConnection <- function(
   bigint = NULL
 ) {
   db <- adbcdrivermanager::adbc_database_init(driver@driver, ...)
+  on.exit(adbc_release(db, "database"))
 
   meta <- list(
     results = list()
   )
 
-  new(
+  connection <- adbcdrivermanager::adbc_connection_init(db)
+  on.exit(
+    adbc_release(connection, "connection"),
+    add = TRUE,
+    after = FALSE
+  )
+
+  out <- new(
     "AdbiConnection",
     database = db,
-    connection = adbcdrivermanager::adbc_connection_init(db),
+    connection = connection,
     metadata = list2env(meta, envir = new.env(parent = emptyenv())),
     bigint = resolve_bigint(bigint),
     rows_affected_callback = rows_affected_callback
   )
+
+  on.exit()
+  out
 }
 
 #' Class AdbiConnection (and methods)

--- a/R/AdbiDriver.R
+++ b/R/AdbiDriver.R
@@ -1,70 +1,112 @@
 #' @include adbi-package.R
 NULL
 
+INVALID_DRIVER_MESSAGE <- paste0(
+  "`driver` must be `NULL`, an `adbc_driver`, a function, ",
+  "or a non-missing character string."
+)
+
 #' Adbi driver
 #'
 #' In order to open a database connection, [DBI::dbConnect()] dispatches on a
 #' driver object, which can be instantiated by calling `adbi()`.
 #'
 #' @details
-#' To specify the type of adbc driver, `adbi` accepts as `driver` argument
+#' `adbi()` stores the `driver` specification in an `AdbiDriver` object. When
+#' that object is passed to [DBI::dbConnect()], the stored value is forwarded
+#' as the `driver` argument of
+#' [adbcdrivermanager::adbc_database_init()]. Additional arguments to
+#' [DBI::dbConnect()] are forwarded to the same function as database options.
 #'
-#' * an object inheriting from `adbc_driver`,
-#' * a function that can be evaluated with no arguments and returns an object
-#'   inheriting from `adbc_driver`,
-#' * a string of the form `pkg::fun` (where `pkg::` is optional and defaults
-#'   to `fun`), which can be used to look up such a function.
+#' Consequently, `adbi()` accepts the same modern driver specifications as
+#' [adbcdrivermanager::adbc_database_init()]:
 #'
-#' As default, an [adbcdrivermanager::adbc_driver_monkey()] object is created.
+#' * `NULL`, which leaves driver selection to the driver manager. Supply a
+#'   `uri` or `profile` argument to [DBI::dbConnect()].
+#' * A non-missing string containing a driver or manifest name, path, or URI.
+#' * An object inheriting from [adbcdrivermanager::adbc_driver].
 #'
-#' @param driver A driver specification that can be evaluated (with no
-#'  arguments) to give an [adbcdrivermanager::adbc_driver()]. See Details for
-#'  more information.
+#' Functions, strings of the form `pkg::fun`, and bare strings that identify an
+#' installed R package and driver function are resolved to an `adbc_driver`
+#' object before forwarding. These forms are supported for backwards
+#' compatibility, but are deprecated. Pass an `adbc_driver` object directly
+#' when using an R driver package.
+#'
+#' @param driver An ADBC driver specification forwarded to the `driver`
+#'   argument of [adbcdrivermanager::adbc_database_init()] when connecting.
+#'   See Details for the accepted values and deprecated compatibility forms.
 #'
 #' @export
 #' @rdname dbConnect
 #' @examples
 #' adbi()
 #' if (requireNamespace("adbcsqlite")) {
-#'   adbi("adbcsqlite")
+#'   adbi(adbcsqlite::adbcsqlite())
 #' }
-adbi <- function(driver = NA_character_) {
+adbi <- function(driver = NULL) {
+  if (is.null(driver) || inherits(driver, "adbc_driver")) {
+    return(new("AdbiDriver", driver = driver))
+  }
+
+  # TODO: In a future breaking release, remove legacy R function/package
+  # resolution and simplify this constructor to a thin wrapper around
+  # adbcdrivermanager driver initialization.
+  if (is.character(driver)) {
+    if (length(driver) != 1L || is.na(driver)) {
+      stop(INVALID_DRIVER_MESSAGE, call. = FALSE)
+    }
+
+    legacy_driver <- adbi_legacy_driver_string(driver)
+
+    if (is.null(legacy_driver)) {
+      return(new("AdbiDriver", driver = driver))
+    }
+
+    adbi_deprecate_legacy_driver()
+    driver <- legacy_driver
+  } else if (is.function(driver)) {
+    adbi_deprecate_legacy_driver()
+  } else {
+    stop(INVALID_DRIVER_MESSAGE, call. = FALSE)
+  }
+
+  driver <- driver()
+
   if (inherits(driver, "adbc_driver")) {
     return(new("AdbiDriver", driver = driver))
   }
 
-  if (is.function(driver)) {
-    drv_obj <- driver()
-  } else {
-    if (is.na(driver)) {
-      pkg <- "adbcdrivermanager"
-      fun <- "adbc_driver_monkey"
-    } else {
-      driver <- strsplit(driver, "::", fixed = TRUE)[[1L]]
+  stop("The driver function must return an `adbc_driver` object.", call. = FALSE)
+}
 
-      if (length(driver) == 1L) {
-        pkg <- fun <- driver
-      } else {
-        stopifnot(length(driver) == 2L)
-
-        pkg <- driver[1L]
-        fun <- driver[2L]
-      }
-    }
-
-    drv_fun <- get(
-      fun,
-      envir = asNamespace(pkg),
-      mode = "function",
-      inherits = FALSE
-    )
-
-    drv_obj <- drv_fun()
+adbi_legacy_driver_string <- function(driver) {
+  if (grepl("://", driver, fixed = TRUE)) {
+    return(NULL)
   }
 
-  stopifnot(inherits(drv_obj, "adbc_driver"))
+  spec <- strsplit(driver, "::", fixed = TRUE)[[1L]]
 
-  new("AdbiDriver", driver = drv_obj)
+  if (length(spec) == 2L) {
+    pkg <- spec[[1L]]
+    fun <- spec[[2L]]
+  } else if (length(spec) == 1L && requireNamespace(driver, quietly = TRUE)) {
+    pkg <- fun <- driver
+  } else {
+    return(NULL)
+  }
+
+  get(fun, envir = asNamespace(pkg), mode = "function", inherits = FALSE)
+}
+
+adbi_deprecate_legacy_driver <- function() {
+  message <- paste0(
+    "Using a function or R package/function string as `driver` is deprecated. ",
+    "Pass an `adbc_driver` object directly. See `?adbi` for supported driver ",
+    "specifications."
+  )
+  warning(
+    simpleWarning(message, call = sys.call(-1L))
+  )
 }
 
 #' Class AdbiDriver (and methods)

--- a/R/AdbiDriver.R
+++ b/R/AdbiDriver.R
@@ -76,7 +76,10 @@ adbi <- function(driver = NULL) {
     return(new("AdbiDriver", driver = driver))
   }
 
-  stop("The driver function must return an `adbc_driver` object.", call. = FALSE)
+  stop(
+    "The driver function must return an `adbc_driver` object.",
+    call. = FALSE
+  )
 }
 
 adbi_legacy_driver_string <- function(driver) {

--- a/R/dbConnect_AdbiDriver.R
+++ b/R/dbConnect_AdbiDriver.R
@@ -10,7 +10,7 @@
 #'   otherwise
 #' @examples
 #' library(DBI)
-#' con <- dbConnect(adbi())
+#' con <- dbConnect(adbi(adbcdrivermanager::adbc_driver_monkey()))
 #' dbIsValid(con)
 #' dbDisconnect(con)
 #' dbIsValid(con)

--- a/R/dbDataType_AdbiDriver.R
+++ b/R/dbDataType_AdbiDriver.R
@@ -2,6 +2,16 @@
 #' @inheritParams DBI::dbDataType
 #' @usage NULL
 dbDataType_AdbiDriver <- function(dbObj, obj, ...) {
+  if (
+    inherits(obj, "blob") &&
+      (is.null(dbObj@driver) || is.character(dbObj@driver))
+  ) {
+    stop(
+      "`dbDataType()` for blob objects requires a connection or a concrete `adbc_driver`.",
+      call. = FALSE
+    )
+  }
+
   db_data_type(obj, dbObj@driver)
 }
 

--- a/R/dbIsValid_AdbiDriver.R
+++ b/R/dbIsValid_AdbiDriver.R
@@ -4,7 +4,13 @@
 #' @inheritParams DBI::dbIsValid
 #' @usage NULL
 dbIsValid_AdbiDriver <- function(dbObj, ...) {
-  inherits(dbObj@driver, "adbc_driver")
+  is.null(dbObj@driver) ||
+    (
+      is.character(dbObj@driver) &&
+        length(dbObj@driver) == 1L &&
+        !is.na(dbObj@driver)
+    ) ||
+    inherits(dbObj@driver, "adbc_driver")
 }
 
 #' @rdname AdbiDriver-class

--- a/R/dbIsValid_AdbiDriver.R
+++ b/R/dbIsValid_AdbiDriver.R
@@ -5,11 +5,9 @@
 #' @usage NULL
 dbIsValid_AdbiDriver <- function(dbObj, ...) {
   is.null(dbObj@driver) ||
-    (
-      is.character(dbObj@driver) &&
-        length(dbObj@driver) == 1L &&
-        !is.na(dbObj@driver)
-    ) ||
+    (is.character(dbObj@driver) &&
+      length(dbObj@driver) == 1L &&
+      !is.na(dbObj@driver)) ||
     inherits(dbObj@driver, "adbc_driver")
 }
 

--- a/R/show_AdbiDriver.R
+++ b/R/show_AdbiDriver.R
@@ -4,7 +4,11 @@
 show_AdbiDriver <- function(object) {
   cat("<AdbiDriver>\n")
 
-  if (dbIsValid(object)) {
+  if (is.null(object@driver)) {
+    cat("  Driver: <driver manager>\n")
+  } else if (is.character(object@driver) && dbIsValid(object)) {
+    cat("  Driver: ", object@driver, "\n", sep = "")
+  } else if (dbIsValid(object)) {
     cat("  Type: <", class(object@driver)[1L], ">\n", sep = "")
   } else {
     cat("  INVALID\n")

--- a/README.Rmd
+++ b/README.Rmd
@@ -38,6 +38,36 @@ To get a bug fix or to use a feature from the development version, you can insta
 devtools::install_github("r-dbi/adbi")
 ```
 
+## Connecting
+
+`adbi()` uses the ADBC driver manager to select a driver from a connection
+profile, URI, driver name, or manifest. When `DBI::dbConnect()` is called,
+the value passed to `adbi()` becomes the `driver` argument of
+`adbcdrivermanager::adbc_database_init()`:
+
+```r
+# Load a connection profile
+con <- DBI::dbConnect(adbi::adbi(), profile = "myprofile")
+
+# Equivalently, use a profile URI
+con <- DBI::dbConnect(adbi::adbi("profile://myprofile"))
+
+# Infer the PostgreSQL driver from the URI scheme
+con <- DBI::dbConnect(
+  adbi::adbi(),
+  uri = "postgresql://localhost/database"
+)
+
+# Load a driver by name
+con <- DBI::dbConnect(
+  adbi::adbi("postgresql"),
+  uri = "postgresql://localhost/database"
+)
+```
+
+An R driver object can still be supplied directly. Resolving an R driver from
+a function or package name is deprecated.
+
 ## Example
 
 The `data.frame` API of DBI is supported.
@@ -49,8 +79,11 @@ The `data.frame` API of DBI is supported.
 
 library(DBI)
 
-# Create an SQLite connection using the adbcsqlite backend
-con <- dbConnect(adbi::adbi("adbcsqlite"), uri = ":memory:")
+# Create an SQLite connection using an R driver object
+con <- dbConnect(
+  adbi::adbi(adbcsqlite::adbcsqlite()),
+  uri = ":memory:"
+)
 
 # Write a table
 dbWriteTable(con, "swiss", datasets::swiss)

--- a/README.md
+++ b/README.md
@@ -32,6 +32,36 @@ can install the development version of adbi from GitHub:
 devtools::install_github("r-dbi/adbi")
 ```
 
+## Connecting
+
+`adbi()` uses the ADBC driver manager to select a driver from a
+connection profile, URI, driver name, or manifest. When
+`DBI::dbConnect()` is called, the value passed to `adbi()` becomes the
+`driver` argument of `adbcdrivermanager::adbc_database_init()`:
+
+``` r
+# Load a connection profile
+con <- DBI::dbConnect(adbi::adbi(), profile = "myprofile")
+
+# Equivalently, use a profile URI
+con <- DBI::dbConnect(adbi::adbi("profile://myprofile"))
+
+# Infer the PostgreSQL driver from the URI scheme
+con <- DBI::dbConnect(
+  adbi::adbi(),
+  uri = "postgresql://localhost/database"
+)
+
+# Load a driver by name
+con <- DBI::dbConnect(
+  adbi::adbi("postgresql"),
+  uri = "postgresql://localhost/database"
+)
+```
+
+An R driver object can still be supplied directly. Resolving an R
+driver from a function or package name is deprecated.
+
 ## Example
 
 The `data.frame` API of DBI is supported.
@@ -43,8 +73,11 @@ The `data.frame` API of DBI is supported.
 
 library(DBI)
 
-# Create an SQLite connection using the adbcsqlite backend
-con <- dbConnect(adbi::adbi("adbcsqlite"), uri = ":memory:")
+# Create an SQLite connection using an R driver object
+con <- dbConnect(
+  adbi::adbi(adbcsqlite::adbcsqlite()),
+  uri = ":memory:"
+)
 
 # Write a table
 dbWriteTable(con, "swiss", datasets::swiss)

--- a/man/dbConnect.Rd
+++ b/man/dbConnect.Rd
@@ -9,16 +9,16 @@
 \alias{dbDisconnect,AdbiConnection-method}
 \title{Adbi driver}
 \usage{
-adbi(driver = NA_character_)
+adbi(driver = NULL)
 
 \S4method{dbConnect}{AdbiDriver}(drv, ..., bigint = NULL)
 
 \S4method{dbDisconnect}{AdbiConnection}(conn, force = getOption("adbi.force_close_results", FALSE), ...)
 }
 \arguments{
-\item{driver}{A driver specification that can be evaluated (with no
-arguments) to give an \code{\link[adbcdrivermanager:adbc_driver]{adbcdrivermanager::adbc_driver()}}. See Details for
-more information.}
+\item{driver}{An ADBC driver specification forwarded to the \code{driver}
+argument of \code{\link[adbcdrivermanager:adbc_database_init]{adbcdrivermanager::adbc_database_init()}} when connecting.
+See Details for the accepted values and deprecated compatibility forms.}
 
 \item{drv}{An object that inherits from
 \link[DBI:DBIDriver-class]{DBI::DBIDriver},
@@ -47,24 +47,34 @@ In order to open a database connection, \code{\link[DBI:dbConnect]{DBI::dbConnec
 driver object, which can be instantiated by calling \code{adbi()}.
 }
 \details{
-To specify the type of adbc driver, \code{adbi} accepts as \code{driver} argument
+\code{adbi()} stores the \code{driver} specification in an \code{AdbiDriver} object. When
+that object is passed to \code{\link[DBI:dbConnect]{DBI::dbConnect()}}, the stored value is forwarded
+as the \code{driver} argument of
+\code{\link[adbcdrivermanager:adbc_database_init]{adbcdrivermanager::adbc_database_init()}}. Additional arguments to
+\code{\link[DBI:dbConnect]{DBI::dbConnect()}} are forwarded to the same function as database options.
+
+Consequently, \code{adbi()} accepts the same modern driver specifications as
+\code{\link[adbcdrivermanager:adbc_database_init]{adbcdrivermanager::adbc_database_init()}}:
 \itemize{
-\item an object inheriting from \code{adbc_driver},
-\item a function that can be evaluated with no arguments and returns an object
-inheriting from \code{adbc_driver},
-\item a string of the form \code{pkg::fun} (where \verb{pkg::} is optional and defaults
-to \code{fun}), which can be used to look up such a function.
+\item \code{NULL}, which leaves driver selection to the driver manager. Supply a
+\code{uri} or \code{profile} argument to \code{\link[DBI:dbConnect]{DBI::dbConnect()}}.
+\item A non-missing string containing a driver or manifest name, path, or URI.
+\item An object inheriting from \link[adbcdrivermanager:adbc_driver]{adbcdrivermanager::adbc_driver}.
 }
 
-As default, an \code{\link[adbcdrivermanager:adbc_driver_monkey]{adbcdrivermanager::adbc_driver_monkey()}} object is created.
+Functions, strings of the form \code{pkg::fun}, and bare strings that identify an
+installed R package and driver function are resolved to an \code{adbc_driver}
+object before forwarding. These forms are supported for backwards
+compatibility, but are deprecated. Pass an \code{adbc_driver} object directly
+when using an R driver package.
 }
 \examples{
 adbi()
 if (requireNamespace("adbcsqlite")) {
-  adbi("adbcsqlite")
+  adbi(adbcsqlite::adbcsqlite())
 }
 library(DBI)
-con <- dbConnect(adbi())
+con <- dbConnect(adbi(adbcdrivermanager::adbc_driver_monkey()))
 dbIsValid(con)
 dbDisconnect(con)
 dbIsValid(con)

--- a/tests/testthat/helper-DBItest.R
+++ b/tests/testthat/helper-DBItest.R
@@ -3,7 +3,7 @@ if (
     requireNamespace("adbcsqlite", quietly = TRUE)
 ) {
   DBItest::make_context(
-    adbi::adbi("adbcsqlite"),
+    adbi::adbi(adbcsqlite::adbcsqlite()),
     list(
       uri = tempfile("DBItest", fileext = ".sqlite"),
       rows_affected_callback = function() {

--- a/tests/testthat/test-DBItest.R
+++ b/tests/testthat/test-DBItest.R
@@ -9,6 +9,9 @@ if (
     skip = c(
       "package_name",
 
+      # DBItest cannot inspect a constructor argument whose default is NULL
+      "constructor",
+
       # options(adbi.allow_multiple_results = FALSE)
       "send_query_only_one_result_set",
       "send_statement_only_one_result_set",

--- a/tests/testthat/test-driver.R
+++ b/tests/testthat/test-driver.R
@@ -1,0 +1,143 @@
+test_that("adbi supports driver-manager inputs", {
+  drv <- adbi()
+  expect_null(drv@driver)
+  expect_true(dbIsValid(drv))
+
+  drv <- adbi("profile://example")
+  expect_identical(drv@driver, "profile://example")
+  expect_true(dbIsValid(drv))
+
+  drv <- adbi("postgresql://localhost/database")
+  expect_identical(drv@driver, "postgresql://localhost/database")
+  expect_true(dbIsValid(drv))
+
+  drv <- adbi("driver_name_that_is_not_an_r_package")
+  expect_identical(drv@driver, "driver_name_that_is_not_an_r_package")
+  expect_true(dbIsValid(drv))
+})
+
+test_that("adbi supports adbc_driver objects", {
+  driver <- adbcdrivermanager::adbc_driver_monkey()
+  drv <- adbi(driver)
+
+  expect_identical(drv@driver, driver)
+  expect_true(dbIsValid(drv))
+})
+
+test_that("legacy driver specifications are deprecated", {
+  driver_function <- adbcdrivermanager::adbc_driver_monkey
+
+  drv <- expect_warning(adbi(driver_function), "deprecated")
+  expect_s3_class(drv@driver, "adbc_driver")
+
+  skip_if_not_installed("adbcsqlite")
+
+  drv <- expect_warning(
+    adbi("adbcsqlite::adbcsqlite"),
+    "deprecated"
+  )
+  expect_s3_class(drv@driver, "adbc_driver")
+
+  drv <- expect_warning(adbi("adbcsqlite"), "deprecated")
+  expect_s3_class(drv@driver, "adbc_driver")
+})
+
+test_that("driver functions are evaluated once", {
+  calls <- 0L
+  driver_function <- function() {
+    calls <<- calls + 1L
+    adbcdrivermanager::adbc_driver_monkey()
+  }
+
+  expect_warning(adbi(driver_function), "deprecated")
+  expect_identical(calls, 1L)
+})
+
+test_that("legacy driver warnings point to adbi", {
+  warning_call <- NULL
+
+  withCallingHandlers(
+    adbi(adbcdrivermanager::adbc_driver_monkey),
+    warning = function(cnd) {
+      warning_call <<- conditionCall(cnd)
+      invokeRestart("muffleWarning")
+    }
+  )
+
+  expect_identical(warning_call[[1L]], quote(adbi))
+})
+
+test_that("adbi rejects invalid drivers", {
+  msg <- getFromNamespace("INVALID_DRIVER_MESSAGE", "adbi")
+
+  expect_error(adbi(character()), msg, fixed = TRUE)
+  expect_error(adbi(c("one", "two")), msg, fixed = TRUE)
+  expect_error(adbi(NA_character_), msg, fixed = TRUE)
+  expect_error(adbi(1), msg, fixed = TRUE)
+  expect_error(
+    expect_warning(adbi(function() NULL), "deprecated"),
+    "must return an `adbc_driver`"
+  )
+})
+
+test_that("show supports driver-manager inputs", {
+  expect_output(show(adbi()), "Driver: <driver manager>", fixed = TRUE)
+  expect_output(
+    show(adbi("profile://example")),
+    "Driver: profile://example",
+    fixed = TRUE
+  )
+})
+
+test_that("dbDataType works without a concrete driver", {
+  expect_identical(dbDataType(adbi(), 1L), "INT")
+  expect_identical(dbDataType(adbi("sqlite"), "x"), "TEXT")
+  expect_error(
+    dbDataType(adbi(), structure(list(as.raw(1)), class = "blob")),
+    "requires a connection"
+  )
+})
+
+test_that("failed connection initialization releases the database", {
+  database <- new.env(parent = emptyenv())
+  released <- FALSE
+
+  testthat::local_mocked_bindings(
+    adbc_database_init = function(...) database,
+    adbc_connection_init = function(...) stop("connection failed"),
+    .package = "adbcdrivermanager"
+  )
+  testthat::local_mocked_bindings(
+    adbc_release = function(...) {
+      released <<- TRUE
+    },
+    .package = "adbi"
+  )
+
+  expect_error(AdbiConnection(adbi()), "connection failed")
+  expect_true(released)
+})
+
+test_that("failure after connection initialization releases all resources", {
+  database <- new.env(parent = emptyenv())
+  connection <- new.env(parent = emptyenv())
+  released <- character()
+
+  testthat::local_mocked_bindings(
+    adbc_database_init = function(...) database,
+    adbc_connection_init = function(...) connection,
+    .package = "adbcdrivermanager"
+  )
+  testthat::local_mocked_bindings(
+    adbc_release = function(x, type) {
+      released <<- c(released, type)
+    },
+    .package = "adbi"
+  )
+
+  expect_error(
+    AdbiConnection(adbi(), bigint = "not-a-bigint-mode"),
+    "'arg' should be one of"
+  )
+  expect_identical(released, c("connection", "database"))
+})

--- a/tests/testthat/test-profile.R
+++ b/tests/testthat/test-profile.R
@@ -1,0 +1,67 @@
+write_adbi_test_driver_manifest <- function(dir, name) {
+  driver_path <- getFromNamespace(
+    "adbcdrivermanager_shared",
+    "adbcdrivermanager"
+  )()
+  content <- sprintf(
+    "
+manifest_version = 1
+
+[ADBC]
+version = 'v1.1.0'
+
+[Driver]
+shared = '%s'
+entrypoint = 'AdbcTestVoidDriverInit'
+",
+    driver_path
+  )
+  path <- file.path(dir, paste0(name, ".toml"))
+  writeLines(content, path)
+  path
+}
+
+write_adbi_test_profile <- function(dir) {
+  manifest_path <- write_adbi_test_driver_manifest(dir, "test_driver")
+  profile_path <- file.path(dir, "test_profile.toml")
+  writeLines(
+    c(
+      "profile_version = 1",
+      sprintf("driver = '%s'", manifest_path),
+      "",
+      "[Options]"
+    ),
+    profile_path
+  )
+  profile_path
+}
+
+test_that("adbi connects using a profile option", {
+  dir <- withr::local_tempdir()
+  profile_path <- write_adbi_test_profile(dir)
+
+  con <- dbConnect(adbi(), profile = profile_path)
+  withr::defer(dbDisconnect(con))
+
+  expect_true(dbIsValid(con))
+})
+
+test_that("adbi connects using a profile URI option", {
+  dir <- withr::local_tempdir()
+  profile_path <- write_adbi_test_profile(dir)
+
+  con <- dbConnect(adbi(), uri = paste0("profile://", profile_path))
+  withr::defer(dbDisconnect(con))
+
+  expect_true(dbIsValid(con))
+})
+
+test_that("adbi connects using a profile URI driver", {
+  dir <- withr::local_tempdir()
+  profile_path <- write_adbi_test_profile(dir)
+
+  con <- dbConnect(adbi(paste0("profile://", profile_path)))
+  withr::defer(dbDisconnect(con))
+
+  expect_true(dbIsValid(con))
+})

--- a/tests/testthat/test-show.R
+++ b/tests/testthat/test-show.R
@@ -1,9 +1,11 @@
 test_that("show methods print", {
-  expect_output(show(adbi()))
+  expect_output(
+    show(adbi(adbcdrivermanager::adbc_driver_monkey()))
+  )
 
   skip_if_not_installed("adbcsqlite")
 
-  drv <- adbi("adbcsqlite::adbcsqlite")
+  drv <- adbi(adbcsqlite::adbcsqlite())
 
   expect_output(show(drv))
 


### PR DESCRIPTION
Close #48
Related to apache/arrow-adbc#4535

Reflecting the ADBC ​​ecosystem's shift from language-specific built-in drivers to shared libraries, use the latest driver manager's feature to support the driver profile specification.

The old method of specifying R package drivers as strings is deprecated and should be removed in the future.

cc @hadley
