### PR TITLE
feat: support ADBC driver specs in `adbi()`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -18,7 +18,7 @@ Depends:
 Imports: 
     DBI (>= 1.2.0),
     methods,
-    adbcdrivermanager (>= 0.8.0),
+    adbcdrivermanager (>= 0.19.0),
     nanoarrow (>= 0.3.0)
 Suggests: 
     testthat,

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,10 @@
+# adbi (development version)
+
+- `adbi()` now accepts ADBC Driver Manager driver names and manifest paths.
+  The new `pkg` argument explicitly selects an R package driver. Implicit R
+  package lookup through `driver` remains available for compatibility but is
+  deprecated.
+
 # adbi 0.1.2 (2024-09-03)
 
 - Docs only update

--- a/R/AdbiDriver.R
+++ b/R/AdbiDriver.R
@@ -30,8 +30,8 @@ NULL
 #' @param driver An ADBC driver object, a function returning one, an ADBC Driver
 #'   Manager driver name or manifest path, or (when `pkg` is supplied) the name
 #'   of a driver function in that package. See Details for more information.
-#' @param pkg An R package containing a driver function, or `NA` to interpret a
-#'   character `driver` as an ADBC Driver Manager driver specification.
+#' @param pkg An R package containing a driver function, or `NA` if no R package
+#'   is explicitly specified.
 #'
 #' @export
 #' @rdname dbConnect
@@ -112,7 +112,7 @@ adbi <- function(driver = NA_character_, pkg = NA_character_) {
         )
       )
       drv_obj <- adbi_package_driver(pkg, fun)
-    } else if (adbi_has_package_driver(driver)) {
+    } else if (adbi_has_package_function(driver)) {
       .Deprecated(
         new = sprintf('adbi(pkg = "%s")', driver),
         msg = sprintf(
@@ -130,7 +130,12 @@ adbi <- function(driver = NA_character_, pkg = NA_character_) {
     }
   }
 
-  stopifnot(inherits(drv_obj, "adbc_driver"))
+  if (!inherits(drv_obj, "adbc_driver")) {
+    stop(
+      "The selected driver function must return an `adbc_driver` object.",
+      call. = FALSE
+    )
+  }
 
   new("AdbiDriver", driver = drv_obj)
 }
@@ -145,7 +150,7 @@ adbi_package_driver <- function(pkg, fun) {
   drv_fun()
 }
 
-adbi_has_package_driver <- function(pkg) {
+adbi_has_package_function <- function(pkg) {
   if (!requireNamespace(pkg, quietly = TRUE)) {
     return(FALSE)
   }

--- a/R/AdbiDriver.R
+++ b/R/AdbiDriver.R
@@ -7,64 +7,150 @@ NULL
 #' driver object, which can be instantiated by calling `adbi()`.
 #'
 #' @details
-#' To specify the type of adbc driver, `adbi` accepts as `driver` argument
+#' To specify the type of ADBC driver, `adbi()` accepts as `driver` argument
 #'
 #' * an object inheriting from `adbc_driver`,
 #' * a function that can be evaluated with no arguments and returns an object
 #'   inheriting from `adbc_driver`,
-#' * a string of the form `pkg::fun` (where `pkg::` is optional and defaults
-#'   to `fun`), which can be used to look up such a function.
+#' * an ADBC Driver Manager driver name or manifest path.
+#'
+#' Use `pkg` to load a driver provided by an R package. By default, the driver
+#' function has the same name as the package; supply a character `driver` to
+#' use a different function. For example, `adbi(pkg = "adbcsqlite")` calls
+#' [adbcsqlite::adbcsqlite()], while
+#' `adbi("adbc_driver_monkey", pkg = "adbcdrivermanager")` calls
+#' [adbcdrivermanager::adbc_driver_monkey()].
+#'
+#' Character values passed through `driver` that identify an R package with a
+#' same-named driver function, and strings of the form `pkg::fun`, are supported
+#' for compatibility but deprecated. Use the explicit `pkg` argument instead.
 #'
 #' As default, an [adbcdrivermanager::adbc_driver_monkey()] object is created.
 #'
-#' @param driver A driver specification that can be evaluated (with no
-#'  arguments) to give an [adbcdrivermanager::adbc_driver()]. See Details for
-#'  more information.
+#' @param driver An ADBC driver object, a function returning one, an ADBC Driver
+#'   Manager driver name or manifest path, or (when `pkg` is supplied) the name
+#'   of a driver function in that package. See Details for more information.
+#' @param pkg An R package containing a driver function, or `NA` to interpret a
+#'   character `driver` as an ADBC Driver Manager driver specification.
 #'
 #' @export
 #' @rdname dbConnect
 #' @examples
 #' adbi()
+#' \dontrun{adbi("sqlite")}
 #' if (requireNamespace("adbcsqlite")) {
-#'   adbi("adbcsqlite")
+#'   adbi(pkg = "adbcsqlite")
 #' }
-adbi <- function(driver = NA_character_) {
+adbi <- function(driver = NA_character_, pkg = NA_character_) {
+  pkg_supplied <- !identical(pkg, NA_character_)
+
+  if (
+    pkg_supplied &&
+      (!is.character(pkg) || length(pkg) != 1L || is.na(pkg) || !nzchar(pkg))
+  ) {
+    stop("`pkg` must be a non-missing character scalar.", call. = FALSE)
+  }
+
   if (inherits(driver, "adbc_driver")) {
+    if (pkg_supplied) {
+      stop(
+        "`pkg` cannot be supplied with an `adbc_driver` object.",
+        call. = FALSE
+      )
+    }
     return(new("AdbiDriver", driver = driver))
   }
 
   if (is.function(driver)) {
+    if (pkg_supplied) {
+      stop(
+        "`pkg` cannot be supplied with a function-valued `driver`.",
+        call. = FALSE
+      )
+    }
     drv_obj <- driver()
   } else {
-    if (is.na(driver)) {
-      pkg <- "adbcdrivermanager"
-      fun <- "adbc_driver_monkey"
-    } else {
-      driver <- strsplit(driver, "::", fixed = TRUE)[[1L]]
-
-      if (length(driver) == 1L) {
-        pkg <- fun <- driver
-      } else {
-        stopifnot(length(driver) == 2L)
-
-        pkg <- driver[1L]
-        fun <- driver[2L]
-      }
+    if (!is.character(driver) || length(driver) != 1L) {
+      stop(
+        "`driver` must be an ADBC driver, a function, or a character scalar.",
+        call. = FALSE
+      )
     }
 
-    drv_fun <- get(
-      fun,
-      envir = asNamespace(pkg),
-      mode = "function",
-      inherits = FALSE
-    )
+    driver_default <- identical(driver, NA_character_)
 
-    drv_obj <- drv_fun()
+    if (pkg_supplied) {
+      fun <- if (driver_default) pkg else driver
+      if (!nzchar(fun) || grepl("::", fun, fixed = TRUE)) {
+        stop(
+          "With `pkg`, `driver` must be a non-empty function name.",
+          call. = FALSE
+        )
+      }
+      drv_obj <- adbi_package_driver(pkg, fun)
+    } else if (driver_default) {
+      pkg <- "adbcdrivermanager"
+      fun <- "adbc_driver_monkey"
+      drv_obj <- adbi_package_driver(pkg, fun)
+    } else if (!nzchar(driver)) {
+      stop("`driver` must not be empty.", call. = FALSE)
+    } else if (grepl("::", driver, fixed = TRUE)) {
+      driver_parts <- strsplit(driver, "::", fixed = TRUE)[[1L]]
+      if (length(driver_parts) != 2L || any(!nzchar(driver_parts))) {
+        stop("A package driver must have the form `pkg::fun`.", call. = FALSE)
+      }
+
+      pkg <- driver_parts[1L]
+      fun <- driver_parts[2L]
+      .Deprecated(
+        new = sprintf('adbi("%s", pkg = "%s")', fun, pkg),
+        msg = sprintf(
+          '`adbi("%s")` is deprecated; use `adbi("%s", pkg = "%s")` instead.',
+          driver,
+          fun,
+          pkg
+        )
+      )
+      drv_obj <- adbi_package_driver(pkg, fun)
+    } else if (adbi_has_package_driver(driver)) {
+      .Deprecated(
+        new = sprintf('adbi(pkg = "%s")', driver),
+        msg = sprintf(
+          paste0(
+            '`adbi("%s")` as an R package lookup is deprecated; ',
+            'use `adbi(pkg = "%s")` instead.'
+          ),
+          driver,
+          driver
+        )
+      )
+      drv_obj <- adbi_package_driver(driver, driver)
+    } else {
+      drv_obj <- adbcdrivermanager::adbc_driver(driver)
+    }
   }
 
   stopifnot(inherits(drv_obj, "adbc_driver"))
 
   new("AdbiDriver", driver = drv_obj)
+}
+
+adbi_package_driver <- function(pkg, fun) {
+  drv_fun <- get(
+    fun,
+    envir = asNamespace(pkg),
+    mode = "function",
+    inherits = FALSE
+  )
+  drv_fun()
+}
+
+adbi_has_package_driver <- function(pkg) {
+  if (!requireNamespace(pkg, quietly = TRUE)) {
+    return(FALSE)
+  }
+
+  exists(pkg, envir = asNamespace(pkg), mode = "function", inherits = FALSE)
 }
 
 #' Class AdbiDriver (and methods)

--- a/README.Rmd
+++ b/README.Rmd
@@ -42,6 +42,15 @@ devtools::install_github("r-dbi/adbi")
 
 The `data.frame` API of DBI is supported.
 
+Drivers can be selected by an ADBC Driver Manager specification, explicitly
+from an R package, or by passing an existing driver object:
+
+```{r driver-selection, eval=FALSE}
+adbi::adbi("sqlite")
+adbi::adbi(pkg = "adbcsqlite")
+adbi::adbi(adbcsqlite::adbcsqlite())
+```
+
 ```{r df}
 # To run this example, please install the adbcsqlite package first.
 # 
@@ -49,8 +58,8 @@ The `data.frame` API of DBI is supported.
 
 library(DBI)
 
-# Create an SQLite connection using the adbcsqlite backend
-con <- dbConnect(adbi::adbi("adbcsqlite"), uri = ":memory:")
+# Create an SQLite connection using the adbcsqlite R package
+con <- dbConnect(adbi::adbi(pkg = "adbcsqlite"), uri = ":memory:")
 
 # Write a table
 dbWriteTable(con, "swiss", datasets::swiss)

--- a/README.md
+++ b/README.md
@@ -36,6 +36,15 @@ devtools::install_github("r-dbi/adbi")
 
 The `data.frame` API of DBI is supported.
 
+Drivers can be selected by an ADBC Driver Manager specification, explicitly
+from an R package, or by passing an existing driver object:
+
+``` r
+adbi::adbi("sqlite")
+adbi::adbi(pkg = "adbcsqlite")
+adbi::adbi(adbcsqlite::adbcsqlite())
+```
+
 ``` r
 # To run this example, please install the adbcsqlite package first.
 # 
@@ -43,8 +52,8 @@ The `data.frame` API of DBI is supported.
 
 library(DBI)
 
-# Create an SQLite connection using the adbcsqlite backend
-con <- dbConnect(adbi::adbi("adbcsqlite"), uri = ":memory:")
+# Create an SQLite connection using the adbcsqlite R package
+con <- dbConnect(adbi::adbi(pkg = "adbcsqlite"), uri = ":memory:")
 
 # Write a table
 dbWriteTable(con, "swiss", datasets::swiss)

--- a/man/dbConnect.Rd
+++ b/man/dbConnect.Rd
@@ -9,16 +9,19 @@
 \alias{dbDisconnect,AdbiConnection-method}
 \title{Adbi driver}
 \usage{
-adbi(driver = NA_character_)
+adbi(driver = NA_character_, pkg = NA_character_)
 
 \S4method{dbConnect}{AdbiDriver}(drv, ..., bigint = NULL)
 
 \S4method{dbDisconnect}{AdbiConnection}(conn, force = getOption("adbi.force_close_results", FALSE), ...)
 }
 \arguments{
-\item{driver}{A driver specification that can be evaluated (with no
-arguments) to give an \code{\link[adbcdrivermanager:adbc_driver]{adbcdrivermanager::adbc_driver()}}. See Details for
-more information.}
+\item{driver}{An ADBC driver object, a function returning one, an ADBC Driver
+Manager driver name or manifest path, or (when \code{pkg} is supplied) the name
+of a driver function in that package. See Details for more information.}
+
+\item{pkg}{An R package containing a driver function, or \code{NA} to interpret a
+character \code{driver} as an ADBC Driver Manager driver specification.}
 
 \item{drv}{An object that inherits from
 \link[DBI:DBIDriver-class]{DBI::DBIDriver},
@@ -47,21 +50,32 @@ In order to open a database connection, \code{\link[DBI:dbConnect]{DBI::dbConnec
 driver object, which can be instantiated by calling \code{adbi()}.
 }
 \details{
-To specify the type of adbc driver, \code{adbi} accepts as \code{driver} argument
+To specify the type of ADBC driver, \code{adbi()} accepts as \code{driver} argument
 \itemize{
 \item an object inheriting from \code{adbc_driver},
 \item a function that can be evaluated with no arguments and returns an object
 inheriting from \code{adbc_driver},
-\item a string of the form \code{pkg::fun} (where \verb{pkg::} is optional and defaults
-to \code{fun}), which can be used to look up such a function.
+\item an ADBC Driver Manager driver name or manifest path.
 }
+
+Use \code{pkg} to load a driver provided by an R package. By default, the driver
+function has the same name as the package; supply a character \code{driver} to
+use a different function. For example, \code{adbi(pkg = "adbcsqlite")} calls
+\code{\link[adbcsqlite:adbcsqlite]{adbcsqlite::adbcsqlite()}}, while
+\code{adbi("adbc_driver_monkey", pkg = "adbcdrivermanager")} calls
+\code{\link[adbcdrivermanager:adbc_driver_monkey]{adbcdrivermanager::adbc_driver_monkey()}}.
+
+Character values passed through \code{driver} that identify an R package with a
+same-named driver function, and strings of the form \code{pkg::fun}, are supported
+for compatibility but deprecated. Use the explicit \code{pkg} argument instead.
 
 As default, an \code{\link[adbcdrivermanager:adbc_driver_monkey]{adbcdrivermanager::adbc_driver_monkey()}} object is created.
 }
 \examples{
 adbi()
+\dontrun{adbi("sqlite")}
 if (requireNamespace("adbcsqlite")) {
-  adbi("adbcsqlite")
+  adbi(pkg = "adbcsqlite")
 }
 library(DBI)
 con <- dbConnect(adbi())

--- a/man/dbConnect.Rd
+++ b/man/dbConnect.Rd
@@ -20,8 +20,8 @@ adbi(driver = NA_character_, pkg = NA_character_)
 Manager driver name or manifest path, or (when \code{pkg} is supplied) the name
 of a driver function in that package. See Details for more information.}
 
-\item{pkg}{An R package containing a driver function, or \code{NA} to interpret a
-character \code{driver} as an ADBC Driver Manager driver specification.}
+\item{pkg}{An R package containing a driver function, or \code{NA} if no R package
+is explicitly specified.}
 
 \item{drv}{An object that inherits from
 \link[DBI:DBIDriver-class]{DBI::DBIDriver},

--- a/tests/testthat/helper-DBItest.R
+++ b/tests/testthat/helper-DBItest.R
@@ -3,7 +3,7 @@ if (
     requireNamespace("adbcsqlite", quietly = TRUE)
 ) {
   DBItest::make_context(
-    adbi::adbi("adbcsqlite"),
+    adbi::adbi(pkg = "adbcsqlite"),
     list(
       uri = tempfile("DBItest", fileext = ".sqlite"),
       rows_affected_callback = function() {

--- a/tests/testthat/test-adbi.R
+++ b/tests/testthat/test-adbi.R
@@ -35,7 +35,7 @@ test_that("pkg explicitly selects an R package driver", {
 
 test_that("legacy package spellings warn and continue to work", {
   local_mocked_bindings(
-    adbi_has_package_driver = function(pkg) identical(pkg, "fakepkg"),
+    adbi_has_package_function = function(pkg) identical(pkg, "fakepkg"),
     adbi_package_driver = function(pkg, fun) {
       expect_identical(pkg, "fakepkg")
       expect_identical(fun, "fakepkg")
@@ -65,7 +65,7 @@ test_that("installed packages without a same-name driver use Driver Manager", {
     .package = "adbcdrivermanager"
   )
 
-  expect_false(adbi_has_package_driver("utils"))
+  expect_false(adbi_has_package_function("utils"))
   expect_identical(adbi("utils")@driver, fake_driver)
 })
 
@@ -80,4 +80,31 @@ test_that("invalid adbi() argument combinations fail clearly", {
   driver <- adbcdrivermanager::adbc_driver_monkey()
   expect_error(adbi(driver, pkg = "utils"), "cannot be supplied")
   expect_error(adbi(function() driver, pkg = "utils"), "cannot be supplied")
+})
+
+test_that("driver functions must return an adbc_driver", {
+  local_mocked_bindings(adbi_package_driver = function(pkg, fun) 42)
+  expect_error(
+    adbi(pkg = "fakepkg"),
+    "must return an `adbc_driver` object",
+    fixed = TRUE
+  )
+
+  local_mocked_bindings(
+    adbi_has_package_function = function(pkg) identical(pkg, "fakepkg")
+  )
+  expect_warning(
+    expect_error(
+      adbi("fakepkg"),
+      "must return an `adbc_driver` object",
+      fixed = TRUE
+    ),
+    class = "deprecatedWarning"
+  )
+
+  expect_error(
+    adbi(function() 42),
+    "must return an `adbc_driver` object",
+    fixed = TRUE
+  )
 })

--- a/tests/testthat/test-adbi.R
+++ b/tests/testthat/test-adbi.R
@@ -1,0 +1,83 @@
+test_that("adbi() retains its default and accepts existing drivers", {
+  default <- adbi()
+  expect_s4_class(default, "AdbiDriver")
+  expect_s3_class(default@driver, "adbc_driver_monkey")
+
+  driver <- adbcdrivermanager::adbc_driver_monkey()
+  result <- adbi(driver)
+  expect_identical(result@driver, driver)
+})
+
+test_that("ADBC driver specifications use the Driver Manager", {
+  seen <- character()
+  fake_driver <- adbcdrivermanager::adbc_driver_monkey()
+  local_mocked_bindings(
+    adbc_driver = function(driver) {
+      seen <<- c(seen, driver)
+      fake_driver
+    },
+    .package = "adbcdrivermanager"
+  )
+
+  expect_identical(adbi("sqlite")@driver, fake_driver)
+  expect_identical(adbi("/tmp/sqlite.toml")@driver, fake_driver)
+  expect_identical(seen, c("sqlite", "/tmp/sqlite.toml"))
+})
+
+test_that("pkg explicitly selects an R package driver", {
+  skip_if_not_installed("adbcsqlite")
+  expect_s3_class(adbi(pkg = "adbcsqlite")@driver, "adbc_driver")
+  expect_s3_class(
+    adbi("adbc_driver_monkey", pkg = "adbcdrivermanager")@driver,
+    "adbc_driver"
+  )
+})
+
+test_that("legacy package spellings warn and continue to work", {
+  local_mocked_bindings(
+    adbi_has_package_driver = function(pkg) identical(pkg, "fakepkg"),
+    adbi_package_driver = function(pkg, fun) {
+      expect_identical(pkg, "fakepkg")
+      expect_identical(fun, "fakepkg")
+      adbcdrivermanager::adbc_driver_monkey()
+    }
+  )
+
+  expect_warning(adbi("fakepkg"), class = "deprecatedWarning")
+  expect_warning(adbi(driver = "fakepkg"), class = "deprecatedWarning")
+})
+
+test_that("pkg::fun warns and continues to work", {
+  expect_warning(
+    adbi("adbcdrivermanager::adbc_driver_monkey"),
+    "pkg =",
+    class = "deprecatedWarning"
+  )
+})
+
+test_that("installed packages without a same-name driver use Driver Manager", {
+  fake_driver <- adbcdrivermanager::adbc_driver_monkey()
+  local_mocked_bindings(
+    adbc_driver = function(driver) {
+      expect_identical(driver, "utils")
+      fake_driver
+    },
+    .package = "adbcdrivermanager"
+  )
+
+  expect_false(adbi_has_package_driver("utils"))
+  expect_identical(adbi("utils")@driver, fake_driver)
+})
+
+test_that("invalid adbi() argument combinations fail clearly", {
+  expect_error(adbi(pkg = character()), "`pkg` must")
+  expect_error(adbi(pkg = ""), "`pkg` must")
+  expect_error(adbi(1), "`driver` must")
+  expect_error(adbi(character()), "`driver` must")
+  expect_error(adbi("", pkg = "utils"), "function name")
+  expect_error(adbi("pkg::fun", pkg = "utils"), "function name")
+
+  driver <- adbcdrivermanager::adbc_driver_monkey()
+  expect_error(adbi(driver, pkg = "utils"), "cannot be supplied")
+  expect_error(adbi(function() driver, pkg = "utils"), "cannot be supplied")
+})

--- a/tests/testthat/test-show.R
+++ b/tests/testthat/test-show.R
@@ -3,7 +3,7 @@ test_that("show methods print", {
 
   skip_if_not_installed("adbcsqlite")
 
-  drv <- adbi("adbcsqlite::adbcsqlite")
+  drv <- adbi(pkg = "adbcsqlite")
 
   expect_output(show(drv))
 


### PR DESCRIPTION
Derived from #56

Fix #48

## Known ambiguity

Keeping implicit R-package lookup for bare strings creates unavoidable conflicts with ADBC driver names.

For example, with the duckdb R package installed, `adbi("duckdb")` resolves to `duckdb::duckdb()` instead of the ADBC `"duckdb"` driver and therefore fails, even if the DuckDB ADBC driver is installed.

This is why implicit package lookup through `driver` should be treated strictly as temporary compatibility behavior and removed after the deprecation period. `pkg =` provides the explicit replacement.